### PR TITLE
replace_special.py update

### DIFF
--- a/AlexDanoff/src/math_mode.py
+++ b/AlexDanoff/src/math_mode.py
@@ -1,4 +1,7 @@
-math_start = {"\\[": "\\]",
+"""
+Dictionary containing math mode delimiters and their respective endpoints.
+"""
+mathStart = {"\\[": "\\]",
              "\\(": "\\)",
              "$$": "$$",
              "$": "$",
@@ -9,9 +12,13 @@ math_start = {"\\[": "\\]",
              "\\begin{multline}": "\\end{multline}",
              "\\begin{multline*}": "\\end{multline*}"}
 
-math_end = ["\\hbox{",
+"""
+List of delimiters that exit math mode.
+"""
+mathEnd = ["\\hbox{",
            "\\mbox{",
-           "\\text{"]
+           "\\text{",
+           "\\label{"]
 
 
 def find_first(string, delim, start=0):
@@ -41,7 +48,7 @@ def first_delim(string, enter=True):
     :return: The delimiter that first appears in the string.
     """
     minm = ["\\hbox{", "\\]"][enter]
-    for delim in [math_end, math_start][enter]:
+    for delim in [mathEnd, mathStart][enter]:
         i = find_first(string, delim)
         if i != -1 and i < find_first(string, minm) or minm not in string:
             minm = delim
@@ -57,7 +64,7 @@ def does_exit(string):
     :param string: The string to check.
     :return: Whether the string starts with a text mode delimiter.
     """
-    return any(string.startswith(delim) for delim in math_end)
+    return any(string.startswith(delim) for delim in mathEnd)
 
 
 def does_enter(string):
@@ -67,7 +74,7 @@ def does_enter(string):
     :param string: The string to check.
     :return: Whether the string starts with a math mode delimiter.
     """
-    return any(string.startswith(delim) for delim in math_start)
+    return any(string.startswith(delim) for delim in mathStart)
 
 
 def parse_math(string, start, ranges):
@@ -95,10 +102,10 @@ def parse_math(string, start, ranges):
                     ranges.append((begin, start + i))
                 i += parse_non_math(string[i:], start + i, ranges)
                 begin = start + i
-            if string[i:].startswith(math_start[delim]):
+            if string[i:].startswith(mathStart[delim]):
                 if begin != start + i:
                     ranges.append((begin, start + i))
-                return i + len(math_start[delim]) - 1
+                return i + len(mathStart[delim]) - 1
         i += 1
     return i
 
@@ -130,7 +137,6 @@ def parse_non_math(string, start, ranges):
             level += 1
         elif string[i] == "}":
             if level == 0 and delim != "":
-                i += 1
                 return i
             else:
                 level -= 1
@@ -138,22 +144,13 @@ def parse_non_math(string, start, ranges):
     return i
 
 
-def find_math_ranges(string,drmf):
+def find_math_ranges(string):
     # type: (str) -> list
     """
     Returns a list of tuples, each tuple denoting a range of math mode.
     :param string: The string to search within.
     :return: A list of tuples denoting math mode ranges.
     """
-    global math_end
-    if drmf == True:
-        string = string.replace("\\drmfnote","\\drmfname")
-        math_end.extend(["\\constraint{",
-                        "\\substitution"
-                        "\\drmfnote{",
-                        "\\drmfname{",
-                        "\\proof{",
-                         "\\label{"])
     ranges = []
     parse_non_math(string, 0, ranges)
     return ranges[:]

--- a/AlexDanoff/src/replace_special.py
+++ b/AlexDanoff/src/replace_special.py
@@ -1,9 +1,8 @@
-"""Replace i, e, and \pi with \iunit, \expe, and \cpi respectively."""
+"""Replace i, e, and \pi with \iunit, \expe, and \cpi respectively. Creates proper spacing for indexes and removes
+unnecessary characters."""
 
-import math_mode
 import re
 import sys
-
 
 # for compatibility with Python 3
 try:
@@ -11,124 +10,246 @@ try:
 except ImportError:
     izip = zip
 
+import math_mode
+import math_function
+import parentheses
 from utilities import writeout
 from utilities import readin
+
+
+EQ_START = r'\begin{equation}'
+EQ_END = r'\end{equation}'
+
+IND_START = r'\index{'
+
+NAME = 0
+SEEN = 1
+
+CASES_START = r'\begin{cases}'
+CASES_END = r'\end{cases}'
+
+EQMIX_START = r'\begin{equationmix}'
+EQMIX_END = r'\end{equationmix}'
+
+STD_REGEX = r'.*?###open_(\d+)###.*?###close_\1###'
+
 
 def main():
     if len(sys.argv) != 3:
 
-        fname = "ZE.1.tex"
-        ofname = "ZE.2.tex"
+        fname = "../../data/ZE.1.tex"
+        ofname = "../../data/ZE.2.tex"
+
     else:
 
         fname = sys.argv[1]
         ofname = sys.argv[2]
 
-    string = open(fname).read()
+    # Below: index_str writes to output file, math_string takes output file as input, and change_original
+    # writes to the output based on the previous output file
+    # print (math_mode.find_math_ranges(fname))
+    unchanged_math = math_function.math_string(fname)
+    math_string = remove_special(unchanged_math)
+    changed_math = math_function.change_original(fname,math_string)
+    formatted = math_function.formatting(changed_math)
 
-    writeout(ofname, replace_special(string))
+    writeout(ofname, formatted)
 
-def string_to_list(_line, _list):
 
-    _output = []
+def remove_special(content):
+    """Removes the excess pieces from the given content and returns the updated version as a string."""
+    counter = 0
+    for function in content:
 
-    if _list != []:
+        lines = function.split('\n')
 
-        for i in range(0, len(_list)):
-            if i == 0:
+        # various flags that will help us keep track of what elements we are inside of currently
+        inside = {
+            "constraint": [r'\constraint{', False],
+            "substitution": [r'\substitution{', False],
+            "drmfnote": [r'\drmfnote{', False],
+            "drmfname": [r'\drmfname{', False],
+            "proof": [r'\proof{', False]
+        }
 
-                _output.append(_line[0:_list[i][0]])
+        should_replace = False
+        in_ind = False
+        in_eq = True
 
-            else:
-
-                _output.append(_line[_list[i-1][1]:_list[i][0]])
-
-            _output.append(_line[_list[i][0]:_list[i][1]])
-
-        if len(_line) != _list[i][1] + 1:
-
-            length = len(_line)
-            _output.append(_line[_list[i][1]:length])
-
-    else:
-        _output.append(_line)
-    return _output
-
-def list_to_string(list):
-
-    output = ""
-    for i in list:
-
-        output += i
-
-    return output
-
-def replace_special(string):
-    ranges = math_mode.find_math_ranges(string,"DRMF" in string)
-    _list = string_to_list(string, ranges)
-    for i in range(1, len(_list), 2):
-
-        iloc = _list[i].find("i", 0, len(_list[i]))
         pi_pat = re.compile(r'(\s*)\\pi(\s*\b|[aeiou])')
         expe_pat = re.compile(r'\b([^\\]?\W*)\s*e\s*\^')
-        _list[i] = pi_pat.sub(r'\1\\cpi\2', _list[i])
-        _list[i] = expe_pat.sub(r'\1\\expe^', _list[i])
 
-        while iloc != -1:
-            surrounding = []
+        spaces_pat = re.compile(r' {2,}')
+        paren_pat = re.compile(r'\(\s*(.*?)\s*\)')
 
-            # ensure "i" does not occur at the beginning of the string
-            if iloc != 0:
+        dollar_pat = re.compile(r'(?<!\\)\$')
 
-                surrounding.append(_list[i][iloc - 1])
-                flag = True
-                # ensure "i" does not occur at the end of the line
-            if iloc != len(_list[i]) - 1:
+        comment_str = ""
 
-                surrounding.append(_list[i][iloc + 1])
+        updated = []
 
-            replacement = _list[i][iloc]
+        # go through content and make replacements where necessary
+        for lnum, line in enumerate(lines):
 
-            if len(surrounding) == 1:
-                if flag == True:
+            lnum += 1
 
-                    surrounding.append("\n")
+            # if this line marks the start of an equation, set the flag
+            if EQ_START in line:
+                in_eq = True
 
-                else:
+                # if this line marks the end of an equation, set the flag
+            if EQ_END in line:
 
-                    surrounding.insert(0,"\n")
-            # at least one of the characters surrounding "i" is not alphabetic, we may need to replace
-            if not (surrounding[0].isalpha() and surrounding[1].isalpha()):
-                # one (but not both) of the surrounding characters IS alphabetic, may need to replace
-                if surrounding[0].isalpha != surrounding[1].isalpha and surrounding[0].isalpha() and surrounding[0] in "aeiou":
-                    replacement = r'\iunit'
+                # remove other flags too
+                for flag in inside:
+                    inside[flag][SEEN] = False
 
-                if surrounding[0].isalpha != surrounding[1].isalpha and not surrounding[0].isalpha and surrounding[0] != "\\":
-                    replacement = r'\iunit '
+                comment_str = ""
 
-                if surrounding[0].isalpha == surrounding[1].isalpha:  # neither of the characters surrounding the "i" are alphabetic, replace
-                    replacement = r'\iunit'
+                in_eq = True
 
-                if (surrounding[0] == " " and surrounding[1] == "}") or (surrounding[0] == "{" and surrounding[1] == " "):
-                    replacement = r'\iunit'
+            # we need to make the replacements in equations
+            if in_eq:
 
-            if "\iunit" in replacement and surrounding[1] == " ":
+                is_comment = line.lstrip().startswith("%")
+
+                line = pi_pat.sub(r'\1\\cpi\2', line)
+                line = expe_pat.sub(r'\1\\expe^', line)
+
+                # only check for flags if the line is comment
+                if is_comment:
+
+                    # go through each possible flag and see if it should be set
+                    for flag, info in inside.iteritems():
+
+                        # name is present in this line, remember that we're in the block
+                        if info[NAME] in line:
+                            inside[flag][SEEN] = True
+
+                    comment_str += parentheses.remove(line, curly=True, cached=True) + "\n"
+
+                # only try to make replacements if this line isn't a comment
+                if not is_comment:
+
+                    line = line.rstrip(".")
+                    line = _replace_i(line)
+
+                elif any(info[SEEN] for info in inside.values()):
+                    # ^we're in a special block, look for dollar signs to replace "i"s
+
+                    # if we're done with a special block
+                    if comment_str.rstrip().endswith("###close_0###"):
+
+                        comment_str = comment_str[:-1]
+
+                        # print([x for x in inside if inside[x][SEEN]])
+
+                        # reset special block flags
+                        for flag in inside:
+                            inside[flag][SEEN] = False
+
+                        # print(comment_str + "\n")
+
+                        dollar_locs = [match.start() for match in dollar_pat.finditer(comment_str)]
+                        locs_iter = iter(dollar_locs)
+
+                        dollar_pairs = [(first, second) for first, second in izip(locs_iter, locs_iter)]
+                        # create a list of ranges that are between dollar signs
+
+                        if len(dollar_locs) % 2:
+                            print("MISMATCHED $ in:\n{0}".format(comment_str))
+                            sys.exit(-1)
+
+                        # replace "i"s within dollar signs
+                        for dollar_pair in dollar_pairs:
+                            comment_str = comment_str[:dollar_pair[0]] + _replace_i(
+                                comment_str[dollar_pair[0]:dollar_pair[1]]) + comment_str[dollar_pair[1]:]
+
+                        comment_lines = parentheses.insert(comment_str, curly=True).split("\n")
+
+                        # comment_lines[-1] = re.sub(r'[.,]}[.,]?', r'}', comment_lines[-1])
+                        # ^ removed bc periods/ commas in comment necessary -oksana
+                        updated.extend(comment_lines)
+
+                        comment_str = ""
+
+                    continue
+
+            updated.append(line)
+
+        function = '\n'.join(updated)
+
+        # remove consecutive blank lines and blank lines between \index groups
+        spaces_pat = re.compile(r'\n{2,}[ ]?\n+')
+        function = spaces_pat.sub('\n\n', function)
+
+        function = re.sub(r'\\index{(.*?)}\n\n\\index{(.*?)}', r'\\index{\1}\n\\index{\2}', function)
+
+        content[counter] = function
+        counter += 1
+    return content
+
+# replaces "i"s as necessary in words
+def _replace_i(words):
+
+    text_pat = re.compile(r'\\text{.*?}')
+
+
+    iloc = words.find("i")
+
+    # go through every occurence of "i" in the content
+    while iloc != -1:
+
+        text_bounds = [(match.start(), match.end()) for match in text_pat.finditer(words)]
+
+        # go through all the text lines
+        for start, end in text_bounds:
+
+            # if the "i" is in the \text tag, skip it
+            if start < iloc < end:
+                iloc = words.find("i", end + 1)
+
+                continue
+
+        surrounding = ""
+
+        # ensure "i" does not occur at the beginning of the string
+        if iloc != 0:
+            surrounding += words[iloc - 1]
+
+            # ensure "i" does not occur at the end of the line
+        if iloc != len(words) - 1:
+            surrounding += words[iloc + 1]
+
+        replacement = words[iloc]
+
+        # at least one of the characters surrounding "i" is not alphabetic, we may need to replace
+        if not surrounding.isalpha():
+
+            # one (but not both) of the surrounding characters IS alphabetic, may need to replace
+            if any(s.isalpha() for s in surrounding):
+
+                """"# character before is alphabetic
+                if surrounding[0].isalpha():
+                    print('caught')  # below was replacing i in ch 16 commands, shraeya wrote unnecessary if char before is vowel
+                    # if surrounding[0] in "aeiou":
+                        # replacement = r'\iunit'"""
+
+                if surrounding[1].isalpha():  # character after is alphabetic
+
+                    # make sure we're not starting a macro
+                    if surrounding[0] != "\\":
+                        replacement = r'\iunit '
+
+            else:  # neither of the characters surrounding the "i" are alphabetic, replace
+
                 replacement = r'\iunit'
+        # print("Surrounding: {0} - replacement made: {1}".format(surrounding, replacement != "i"))
+        words = words[:iloc] + replacement + words[iloc + 1:]
 
-            # print("Surrounding: {0} - replacement made: {1}".format(surrounding, replacement != "i"))
-            _list[i] = _list[i][:iloc] + replacement + _list[i][iloc + 1:]
-            if replacement == r'\iunit':
-                iloc = _list[i].find("i", iloc + 1, len(_list[i]))
-                iloc = _list[i].find("i", iloc + 1, len(_list[i]))
-            iloc = _list[i].find("i", iloc + 1, len(_list[i]))
-    return list_to_string(_list)
+        iloc = words.find("i", iloc + len(replacement))
+    return words
+
 
 if __name__ == "__main__":
     main()
-
-
-
-
-
-
-

--- a/AlexDanoff/test/test_no_math.py
+++ b/AlexDanoff/test/test_no_math.py
@@ -1,0 +1,81 @@
+"""Checks to see if DRMF file has only math mode, whitespace, and the text before
+    first and after last math mode left after running replace_special.py"""
+import re
+import math_mode
+from unittest import TestCase
+
+
+begin_end = r'\\[begin]*[end]*{equation}'  # begin end equation environment
+allSections = r'\\[a-zA-Z]*section'
+
+infile = open('/home/ont1/DLMF/25.ZE/newMoritz/ZE.2.tex').read()
+# 25.ZE/newMoritz/in.tex
+
+def mainman():
+    formatted = no_indices(infile.split('\n'))  # no indices
+    removed_math = no_math(formatted)
+    no_space = remove_command(removed_math)  # Empty
+    # no_space = no_space.replace('\n',"")
+    return no_space
+
+
+def no_indices(content):
+    # returns the input file without index or subsections
+    section = re.compile(allSections)
+    new_content = content[:]
+    for line in content:
+        if "\\index" in line or re.match(section, line):
+            new_content.remove(line)
+    return "\n".join(new_content)
+
+
+def no_math(in_str):
+    # Only remove math mode before first/ after last begin{equation} and within those environments
+    # No special cases such as between dollar signs
+    in_eq = False
+    ranges = math_mode.find_math_ranges(in_str)
+    in_str = in_str[ranges[0][0]:ranges[-1][1]]
+    lines = in_str.split('\n')
+    needed_lines = lines[:]
+    been_in_eq = False
+
+    for line in lines:
+        if '\\begin{equation}' in line:
+            been_in_eq = True
+            in_eq = True
+        if '\\end{equation}' in line:
+            in_eq = False
+        if in_eq:
+            needed_lines.remove(line)
+        if not been_in_eq:
+            needed_lines.remove(line)
+    return '\n'.join(needed_lines)
+
+
+def remove_command(content):
+    spaces = r'\s+'
+    # removes the command that brings into and out of math mode
+    commands = re.findall(begin_end, infile)
+    new_list = content.split('\n')
+    copy = []
+    for i in range(len(new_list)):
+        for command in commands:  # check if command in any of the lists, react appropriately
+            if command in new_list[i]:
+                new_list[i] = new_list[i].replace(command, "")
+                commands.remove(command)
+        if not re.match(spaces, new_list[i]) and new_list[i] != '':
+            copy.append(new_list[i])
+    return "".join(copy)  # if wish to make output more readable, change to '\n'
+
+#print mainman()
+
+# unittest Test Case starts below
+class TestNoMath(TestCase):
+    def test_no_math(self):
+        self.assertEqual(mainman(), "")
+
+
+
+# Fix this:
+# write out to out.tex or make the unittest an actual unittest that returns values and stuff
+# ask about what to do about all of the other text that is appearing


### PR DESCRIPTION
Removes text between begin{equation}/ end{equation} environments. Unittest test_no_math.py tests for the aforementioned. Edit to math_mode.py : added \label to list of commands bringing you out of math mode.